### PR TITLE
Configure SonarQube Cloud CI-based analysis and QG badge

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,22 @@
+name: SonarQube Cloud Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarqube:
+    name: SonarQube Cloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarqube.us

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -12,11 +12,11 @@ jobs:
     name: SonarQube Cloud Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarqube.us

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        uses: SonarSource/sonarqube-scan-action@v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarqube.us

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # factorio-router
 
+[![Quality Gate Status](https://sonarqube.us/api/project_badges/measure?project=afloresescarcega_factorio-router&metric=alert_status)](https://sonarqube.us/summary/new_code?id=afloresescarcega_factorio-router)
+
 A simple program to come up with an inefficient routing plan for all your factory machines and supplies.
 
 This project consumes a Helmod Factorio Calculator's export string and produces a basic blueprint with an inefficient layout (route) of inputs to machines.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=afloresescarcega_factorio-router
+sonar.organization=afloresescarcega-org
+
+sonar.sources=.
+sonar.exclusions=frontend/node_modules/**,frontend/build/**,helmod-decoder/venv/**,**/__pycache__/**,.idea/**,.aider*/**


### PR DESCRIPTION
## Summary
- Add `sonar-project.properties` (project key `afloresescarcega_factorio-router`, org `afloresescarcega-org`), scanning the whole repo minus build/venv/node_modules artifacts.
- Add `.github/workflows/sonarqube.yml` running `SonarSource/sonarqube-scan-action@v4.1.0` on push to `main` and on PRs, targeting the US region host (`SONAR_HOST_URL: https://sonarqube.us`) via the `SONAR_TOKEN` secret.
- Add the Quality Gate badge to `README.md`, linking to the project's summary page on sonarqube.us.

Automatic Analysis has already been disabled on the SonarQube Cloud side and `SONAR_TOKEN` is already set as a repo secret, so this workflow should run cleanly once merged.

## Test plan
- [ ] Merge and confirm the `SonarQube Cloud Scan` workflow run succeeds
- [ ] Confirm the Quality Gate badge renders on the README