### PR TITLE
Fix failing SonarQube Quality Gate (reliability, security, coverage)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -17,6 +12,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,7 +21,7 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
+      - run: npm ci --ignore-scripts
         working-directory: frontend
       - run: npm run build
         working-directory: frontend
@@ -37,6 +34,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,6 +15,30 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: helmod-decoder/requirements-dev.txt
+      - name: Run Python tests with coverage
+        working-directory: helmod-decoder
+        run: |
+          pip install -r requirements-dev.txt
+          python -m pytest --cov=. --cov-report=xml tests/
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Run frontend tests with coverage
+        working-directory: frontend
+        run: |
+          npm ci --ignore-scripts
+          CI=true npx react-scripts test --coverage --watchAll=false
+          node --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage-node/lcov.info --test cli.test.mjs validator/validate.test.mjs
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           npm ci --ignore-scripts
           CI=true npx react-scripts test --coverage --watchAll=false
+          mkdir -p coverage-node
           node --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage-node/lcov.info --test cli.test.mjs validator/validate.test.mjs
 
       - name: SonarQube Scan

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/coverage-node
 
 # production
 /build

--- a/frontend/cli.test.mjs
+++ b/frontend/cli.test.mjs
@@ -1,0 +1,80 @@
+// Tests for the stdin->stdout CLI wrapper. cli.mjs is a top-level script
+// with import-time side effects (it reads stdin immediately), so it's
+// exercised end-to-end via child_process rather than imported directly.
+// Run with: node --test cli.test.mjs
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { HelmodFactory } from './src/helmodFactory.js';
+import { decodeBlueprint } from './src/blueprintFactory.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(here, 'cli.mjs');
+
+function runCli(input, args = []) {
+  return spawnSync('node', [cliPath, ...args], {
+    input,
+    encoding: 'utf-8',
+  });
+}
+
+function validHelmodInput() {
+  return HelmodFactory.encodeHelmod({
+    root: {
+      type: 'recipe',
+      name: 'iron-gear-wheel',
+      factory: { name: 'assembling-machine-1', count: 1 },
+    },
+  });
+}
+
+describe('cli.mjs', () => {
+  test('prints a valid blueprint string and exits 0 for valid input', () => {
+    const result = runCli(validHelmodInput());
+    assert.equal(result.status, 0);
+    const stdout = result.stdout.trim();
+    assert.equal(stdout[0], '0');
+    // Should decode to an actual blueprint object.
+    const decoded = decodeBlueprint(stdout);
+    assert.equal(decoded.blueprint.item, 'blueprint');
+    // Non-debug runs keep stdout clean (no console.log noise mixed in).
+    assert.equal(stdout.split('\n').length, 1);
+    assert.match(result.stderr, /Blueprint passed schema \+ name validation\./);
+  });
+
+  test('dumps decoded stages to stderr under --debug, blueprint string as the last stdout line', () => {
+    const result = runCli(validHelmodInput(), ['--debug']);
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /=== decoded helmod data ===/);
+    assert.match(result.stderr, /=== round-trip decoded blueprint ===/);
+    // Under --debug, main.js's own console.log calls are left active (they
+    // write verbose JSON dumps to stdout too), so unlike the non-debug case
+    // stdout isn't a single clean line -- but the final line is still the
+    // blueprint string.
+    const lines = result.stdout.trim().split('\n');
+    const lastLine = lines[lines.length - 1];
+    assert.equal(lastLine[0], '0');
+    assert.doesNotThrow(() => decodeBlueprint(lastLine));
+  });
+
+  test('exits non-zero and reports schema validation failures for an invalid blueprint', () => {
+    const badInput = HelmodFactory.encodeHelmod({
+      root: {
+        type: 'recipe',
+        name: 'iron-gear-wheel',
+        factory: { name: 'not-a-real-factory', count: 1 },
+      },
+    });
+    const result = runCli(badInput);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Blueprint failed validation:/);
+    assert.match(result.stderr, /itemFluidSignalRecipeEntityName|entityName/);
+  });
+
+  test('exits non-zero for input that cannot be decoded at all', () => {
+    const result = runCli('not a valid helmod export string !!!');
+    assert.notEqual(result.status, 0);
+  });
+});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
+import { HelmodFactory } from './helmodFactory';
 
 test('renders the converter heading', () => {
   render(<App />);
@@ -11,4 +13,39 @@ test('renders the input form with a convert button', () => {
   render(<App />);
   expect(screen.getByPlaceholderText(/enter helmod string/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /convert/i })).toBeInTheDocument();
+});
+
+test('shows an error message when the input cannot be converted', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  render(<App />);
+
+  await userEvent.type(screen.getByPlaceholderText(/enter helmod string/i), 'not a valid helmod string');
+  await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+
+  expect(await screen.findByText(/error:/i)).toBeInTheDocument();
+  console.error.mockRestore();
+});
+
+test('shows the resulting blueprint string on a successful conversion', async () => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const helmodString = HelmodFactory.encodeHelmod({
+    root: {
+      type: 'recipe',
+      name: 'iron-gear-wheel',
+      factory: { name: 'assembling-machine-1', count: 1 },
+    },
+  });
+
+  render(<App />);
+  const textarea = screen.getByPlaceholderText(/enter helmod string/i);
+  await userEvent.type(textarea, helmodString);
+  await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+
+  expect(await screen.findByText(/blueprint string:/i)).toBeInTheDocument();
+  expect(screen.getByDisplayValue(/^0/)).toBeInTheDocument();
+
+  console.log.mockRestore();
+  console.warn.mockRestore();
 });

--- a/frontend/src/blueprintFactory.test.js
+++ b/frontend/src/blueprintFactory.test.js
@@ -1,0 +1,75 @@
+import { encodeBlueprint, decodeBlueprint } from './blueprintFactory';
+
+describe('blueprintFactory', () => {
+  test('round-trips a simple blueprint object', () => {
+    const blueprint = {
+      blueprint: {
+        icons: [{ signal: { type: 'item', name: 'iron-plate' }, index: 1 }],
+        entities: [
+          { entity_number: 1, name: 'transport-belt', position: { x: 0, y: 0 }, direction: 4 },
+        ],
+        item: 'blueprint',
+        label: 'Test blueprint',
+        version: 281479275151360,
+      },
+    };
+
+    const encoded = encodeBlueprint(blueprint);
+    expect(typeof encoded).toBe('string');
+    // Version prefix character, per Factorio's blueprint string format.
+    expect(encoded[0]).toBe('0');
+
+    const decoded = decodeBlueprint(encoded);
+    expect(decoded).toEqual(blueprint);
+  });
+
+  test('round-trips nested structures, booleans, negative numbers and nulls', () => {
+    const blueprint = {
+      blueprint: {
+        entities: [
+          {
+            entity_number: 1,
+            name: 'constant-combinator',
+            position: { x: -3.5, y: 12 },
+            control_behavior: {
+              filters: [{ signal: { type: 'item', name: 'copper-plate' }, count: -1, index: 1 }],
+              enabled: false,
+            },
+            note: null,
+          },
+        ],
+        item: 'blueprint',
+        version: 0,
+      },
+    };
+
+    const decoded = decodeBlueprint(encodeBlueprint(blueprint));
+    expect(decoded).toEqual(blueprint);
+  });
+
+  test('round-trips an empty entities array', () => {
+    const blueprint = { blueprint: { entities: [], item: 'blueprint', version: 1 } };
+    const decoded = decodeBlueprint(encodeBlueprint(blueprint));
+    expect(decoded).toEqual(blueprint);
+  });
+
+  test('chunks large payloads without corrupting the data', () => {
+    // Build a blueprint large enough to exceed the 0x8000-byte chunk size
+    // used internally when converting the deflated bytes to a binary string.
+    const entities = [];
+    for (let i = 0; i < 5000; i++) {
+      entities.push({
+        entity_number: i + 1,
+        name: 'transport-belt',
+        position: { x: i, y: 0 },
+        direction: 4,
+      });
+    }
+    const blueprint = { blueprint: { entities, item: 'blueprint', version: 1 } };
+
+    const encoded = encodeBlueprint(blueprint);
+    const decoded = decodeBlueprint(encoded);
+    expect(decoded.blueprint.entities.length).toBe(5000);
+    expect(decoded).toEqual(blueprint);
+  });
+});

--- a/frontend/src/helmodFactory.test.js
+++ b/frontend/src/helmodFactory.test.js
@@ -1,0 +1,128 @@
+import { HelmodFactory } from './helmodFactory';
+
+describe('HelmodFactory.luaToPython', () => {
+  test('parses unquoted (identifier) keys', () => {
+    expect(HelmodFactory.luaToPython('{foo="bar"}')).toEqual({ foo: 'bar' });
+  });
+
+  test('parses quoted keys, both single and double quotes', () => {
+    expect(HelmodFactory.luaToPython('{["foo-bar"]="baz"}')).toEqual({ 'foo-bar': 'baz' });
+    expect(HelmodFactory.luaToPython("{['weird key']='val'}")).toEqual({ 'weird key': 'val' });
+  });
+
+  test('parses booleans and nil', () => {
+    expect(HelmodFactory.luaToPython('{a=true,b=false,c=nil}')).toEqual({
+      a: true,
+      b: false,
+      c: null,
+    });
+  });
+
+  test('parses negative and floating point numbers', () => {
+    expect(HelmodFactory.luaToPython('{a=-5,b=3.14,c=-2.5,d=1e3}')).toEqual({
+      a: -5,
+      b: 3.14,
+      c: -2.5,
+      d: 1000,
+    });
+  });
+
+  test('parses bare (array-style) entries with 1-based indices', () => {
+    expect(HelmodFactory.luaToPython('{"x","y","z"}')).toEqual({ 1: 'x', 2: 'y', 3: 'z' });
+  });
+
+  test('parses empty tables', () => {
+    expect(HelmodFactory.luaToPython('{}')).toEqual({});
+  });
+
+  test('parses nested tables', () => {
+    const result = HelmodFactory.luaToPython('{a={b={c=1}},d={1,2,3}}');
+    expect(result).toEqual({ a: { b: { c: 1 } }, d: { 1: 1, 2: 2, 3: 3 } });
+  });
+
+  test('parses a realistic Helmod-shaped table', () => {
+    const lua =
+      '{type="recipe",name="iron-gear-wheel",factory={name="assembling-machine-1",count=2.5},children={}}';
+    const result = HelmodFactory.luaToPython(lua);
+    expect(result).toEqual({
+      type: 'recipe',
+      name: 'iron-gear-wheel',
+      factory: { name: 'assembling-machine-1', count: 2.5 },
+      children: {},
+    });
+  });
+
+  test('parses single-quoted strings', () => {
+    expect(HelmodFactory.luaToPython("{name='iron-plate'}")).toEqual({ name: 'iron-plate' });
+  });
+
+  test('throws on an unterminated string', () => {
+    expect(() => HelmodFactory.luaToPython('{a="unterminated}')).toThrow(/Unterminated string/);
+  });
+
+  test('throws on an unterminated bracket key', () => {
+    expect(() => HelmodFactory.luaToPython('{[a=1}')).toThrow(/Unterminated '\[' key/);
+  });
+
+  test('throws when "=" is missing after a bracket key', () => {
+    expect(() => HelmodFactory.luaToPython('{[1]1}')).toThrow(/Expected '=' after key/);
+  });
+
+  test('throws on an unparsable value', () => {
+    expect(() => HelmodFactory.luaToPython('{a=$$$}')).toThrow(/Unable to parse/);
+  });
+
+  test('throws when a table is not closed', () => {
+    expect(() => HelmodFactory.luaToPython('{a=1')).toThrow(/Expected '}'/);
+  });
+});
+
+describe('HelmodFactory.pythonToLua', () => {
+  test('serializes plain objects with identifier keys unquoted', () => {
+    expect(HelmodFactory.pythonToLua({ foo: 'bar' })).toBe('{foo="bar"}');
+  });
+
+  test('quotes keys that are not valid Lua identifiers', () => {
+    expect(HelmodFactory.pythonToLua({ 'foo-bar': 1 })).toBe('{["foo-bar"]=1}');
+  });
+
+  test('serializes arrays as bare Lua tables', () => {
+    expect(HelmodFactory.pythonToLua(['a', 'b'])).toBe('{"a","b"}');
+  });
+
+  test('serializes booleans, null and numbers', () => {
+    expect(HelmodFactory.pythonToLua({ a: true, b: false, c: null, d: -3.5 })).toBe(
+      '{a=true,b=false,c=nil,d=-3.5}'
+    );
+  });
+
+  test('serializes nested objects', () => {
+    expect(HelmodFactory.pythonToLua({ a: { b: 1 } })).toBe('{a={b=1}}');
+  });
+});
+
+describe('HelmodFactory encode/decode round-trip', () => {
+  test('round-trips a nested structure through deflate + base64', () => {
+    const data = {
+      type: 'recipe',
+      name: 'electronic-circuit',
+      factory: { name: 'assembling-machine-2', count: 3 },
+      flag: true,
+      empty: {},
+      list: { 1: 'a', 2: 'b' },
+    };
+    const encoded = HelmodFactory.encodeHelmod(data);
+    expect(typeof encoded).toBe('string');
+    const decoded = HelmodFactory.decodeHelmod(encoded);
+    expect(decoded).toEqual(data);
+  });
+
+  test('strips whitespace/newlines from the encoded string before decoding', () => {
+    const data = { a: 1, b: 'x' };
+    const encoded = HelmodFactory.encodeHelmod(data);
+    // Simulate a pasted multi-line export with embedded whitespace/newlines.
+    const withWhitespace = encoded.match(/.{1,20}/g).join('\n ');
+    const decoded = HelmodFactory.decodeHelmod(withWhitespace);
+    expect(decoded).toEqual(data);
+  });
+});

--- a/frontend/src/index.test.js
+++ b/frontend/src/index.test.js
@@ -1,0 +1,13 @@
+test('renders into #root without crashing', () => {
+  const div = document.createElement('div');
+  div.id = 'root';
+  document.body.appendChild(div);
+
+  // index.js runs its ReactDOM.createRoot(...).render(...) as a side effect
+  // at import time, so requiring it here (after #root exists) exercises it.
+  expect(() => {
+    require('./index');
+  }).not.toThrow();
+
+  document.body.removeChild(div);
+});

--- a/frontend/src/main.test.js
+++ b/frontend/src/main.test.js
@@ -1,0 +1,209 @@
+import { HelmodFactory } from './helmodFactory';
+import { decodeBlueprint } from './blueprintFactory';
+import { processHelmodString } from './main';
+
+// Helper: build an encoded Helmod export string from a plain JS object shaped
+// like Helmod's export data, the same way the real Helmod mod would.
+function encodeHelmodData(data) {
+  return HelmodFactory.encodeHelmod(data);
+}
+
+function recipeNode(name, factoryName, count) {
+  return { type: 'recipe', name, factory: { name: factoryName, count } };
+}
+
+let logSpy, warnSpy, errorSpy;
+beforeEach(() => {
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe('processHelmodString error handling', () => {
+  test('throws when no recipe nodes are present in the data', () => {
+    const encoded = encodeHelmodData({ block: { name: 'not a recipe' } });
+    expect(() => processHelmodString(encoded)).toThrow(
+      /No recipes with factories found/
+    );
+  });
+
+  test('wraps corrupted/non-base64 input in a descriptive error', () => {
+    expect(() => processHelmodString('not valid base64 !!! %%%')).toThrow(
+      /Failed to process Helmod string/
+    );
+  });
+
+  test('wraps an empty string input in a descriptive error', () => {
+    expect(() => processHelmodString('')).toThrow(/Failed to process Helmod string/);
+  });
+});
+
+describe('processHelmodString basic conversion', () => {
+  test('converts a single recipe unknown to the vanilla recipe graph', () => {
+    const encoded = encodeHelmodData({
+      root: recipeNode('totally-fake-recipe', 'assembling-machine-1', 1),
+    });
+
+    const result = processHelmodString(encoded);
+    expect(typeof result).toBe('string');
+    expect(result[0]).toBe('0');
+
+    const decoded = decodeBlueprint(result);
+    expect(decoded.blueprint.item).toBe('blueprint');
+    expect(decoded.blueprint.icons[0].signal.name).toBe('assembling-machine-1');
+    expect(decoded.blueprint.label).toContain('totally-fake-recipe');
+
+    const machine = decoded.blueprint.entities.find(e => e.name === 'assembling-machine-1');
+    expect(machine).toBeDefined();
+    // Recipe not found in vanilla graph => no ingredients, still gets recipe set
+    // (assembling machines accept an explicit recipe).
+    expect(machine.recipe).toBe('totally-fake-recipe');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not in vanilla data')
+    );
+  });
+
+  test('does not set a recipe on furnaces, mining drills or pumpjacks', () => {
+    const encoded = encodeHelmodData({
+      a: recipeNode('unknown-a', 'stone-furnace', 1),
+      b: recipeNode('unknown-b', 'electric-mining-drill', 1),
+      c: recipeNode('unknown-c', 'pumpjack', 1),
+    });
+
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    const furnace = decoded.blueprint.entities.find(e => e.name === 'stone-furnace');
+    const drill = decoded.blueprint.entities.find(e => e.name === 'electric-mining-drill');
+    const pump = decoded.blueprint.entities.find(e => e.name === 'pumpjack');
+    expect(furnace.recipe).toBeUndefined();
+    expect(drill.recipe).toBeUndefined();
+    expect(pump.recipe).toBeUndefined();
+  });
+
+  test('rounds up fractional factory counts and defaults invalid counts to 1', () => {
+    const encoded = encodeHelmodData({
+      // 2.4 factories => ceil to 3
+      furnace: recipeNode('iron-plate', 'stone-furnace', 2.4),
+      // Non-numeric count => NaN => defaults to 1
+      assembler: recipeNode('iron-gear-wheel', 'assembling-machine-1', 'not-a-number'),
+    });
+
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    const furnaces = decoded.blueprint.entities.filter(e => e.name === 'stone-furnace');
+    const assemblers = decoded.blueprint.entities.filter(e => e.name === 'assembling-machine-1');
+    expect(furnaces.length).toBe(3);
+    expect(assemblers.length).toBe(1);
+    // Furnace produces iron-plate consumed by the assembler => intermediate bus.
+    expect(assemblers[0].recipe).toBe('iron-gear-wheel');
+  });
+
+  test('routes a chain of recipes through an intermediate bus', () => {
+    const encoded = encodeHelmodData({
+      producer: recipeNode('iron-plate', 'stone-furnace', 1),
+      consumer: recipeNode('iron-gear-wheel', 'assembling-machine-1', 1),
+    });
+
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    const entities = decoded.blueprint.entities;
+    expect(entities.some(e => e.name === 'transport-belt')).toBe(true);
+    expect(entities.some(e => e.name === 'inserter')).toBe(true);
+    expect(entities.some(e => e.name === 'medium-electric-pole')).toBe(true);
+    expect(entities.some(e => e.name === 'splitter')).toBe(true);
+  });
+});
+
+describe('processHelmodString ingredient lane handling', () => {
+  test('uses all three ingredient lanes (including long-handed inserters) for a 3-ingredient recipe', () => {
+    // speed-module-2 needs exactly 3 item ingredients: speed-module,
+    // advanced-circuit, processing-unit.
+    const encoded = encodeHelmodData({
+      root: recipeNode('speed-module-2', 'assembling-machine-2', 1),
+    });
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    const entities = decoded.blueprint.entities;
+    expect(entities.some(e => e.name === 'long-handed-inserter' && e.direction === 6)).toBe(true);
+    expect(entities.some(e => e.name === 'long-handed-inserter' && e.direction === 2)).toBe(true);
+  });
+
+  test('warns and truncates to 3 lanes when a recipe has more than 3 item ingredients', () => {
+    // bulk-inserter needs 4+ item ingredients.
+    const encoded = encodeHelmodData({
+      root: recipeNode('bulk-inserter', 'assembling-machine-2', 1),
+    });
+    processHelmodString(encoded);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('only the first 3 item ingredients get a belt lane')
+    );
+  });
+
+  test('warns about unrouted fluid ingredients', () => {
+    // sulfuric-acid needs sulfur + iron-plate (items) and water (fluid).
+    const encoded = encodeHelmodData({
+      root: recipeNode('sulfuric-acid', 'chemical-plant', 1),
+    });
+    processHelmodString(encoded);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('fluid ingredients not routed')
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('water'));
+  });
+});
+
+describe('processHelmodString bus limits and column wrapping', () => {
+  test('wraps a factory count greater than 15 into multiple columns', () => {
+    const encoded = encodeHelmodData({
+      root: recipeNode('unknown-big', 'assembling-machine-2', 20),
+    });
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    const machines = decoded.blueprint.entities.filter(e => e.name === 'assembling-machine-2');
+    expect(machines.length).toBe(20);
+    const xs = new Set(machines.map(m => m.position.x));
+    // 20 splits into a column of 15 at x=0 and a column of 5 at x=10.
+    expect(xs.has(0)).toBe(true);
+    expect(xs.has(10)).toBe(true);
+  });
+
+  test('drops buses beyond the first 3 distinct consumed items and warns', () => {
+    // Chain: copper-ore -(furnace)-> copper-plate -(assembler)-> copper-cable
+    // -(assembler)-> electronic-circuit, which also needs external iron-plate.
+    // That is 4 distinct consumed items overall (copper-ore, copper-plate,
+    // iron-plate, copper-cable) which exceeds the 3-bus limit.
+    const encoded = encodeHelmodData({
+      a: recipeNode('copper-plate', 'stone-furnace', 1),
+      b: recipeNode('copper-cable', 'assembling-machine-1', 1),
+      c: recipeNode('electronic-circuit', 'assembling-machine-2', 1),
+    });
+
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('More than 3 items consumed')
+    );
+    // With multiple bus rows in play, at least one bus sits off the -4 row,
+    // which routes through underground belts instead of plain belts.
+    expect(decoded.blueprint.entities.some(e => e.name === 'underground-belt')).toBe(true);
+    // An externally-fed bus gets a constant-combinator label.
+    expect(decoded.blueprint.entities.some(e => e.name === 'constant-combinator')).toBe(true);
+  });
+});
+
+describe('processHelmodString recursive extraction', () => {
+  test('finds recipe nodes nested at arbitrary depth, ignoring non-recipe nodes', () => {
+    const encoded = encodeHelmodData({
+      wrapper: {
+        list: {
+          1: { type: 'block', name: 'ignored' },
+          2: recipeNode('iron-gear-wheel', 'assembling-machine-1', 1),
+        },
+        note: 'irrelevant string node',
+        flag: true,
+      },
+    });
+    const decoded = decodeBlueprint(processHelmodString(encoded));
+    expect(decoded.blueprint.entities.some(e => e.name === 'assembling-machine-1')).toBe(true);
+  });
+});

--- a/frontend/src/reportWebVitals.test.js
+++ b/frontend/src/reportWebVitals.test.js
@@ -1,0 +1,55 @@
+// Jest hoists jest.mock() factories above imports and forbids them from
+// closing over normal out-of-scope variables; names prefixed with "mock"
+// are special-cased as allowed.
+const mockGetCLS = jest.fn();
+const mockGetFID = jest.fn();
+const mockGetFCP = jest.fn();
+const mockGetLCP = jest.fn();
+const mockGetTTFB = jest.fn();
+
+jest.mock('web-vitals', () => ({
+  getCLS: (...args) => mockGetCLS(...args),
+  getFID: (...args) => mockGetFID(...args),
+  getFCP: (...args) => mockGetFCP(...args),
+  getLCP: (...args) => mockGetLCP(...args),
+  getTTFB: (...args) => mockGetTTFB(...args),
+}));
+
+import reportWebVitals from './reportWebVitals';
+
+describe('reportWebVitals', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('reports each web vital to the provided callback', async () => {
+    // jest.fn() mocks are created in a different VM realm than jsdom's
+    // globals in this Jest/jsdom setup, which makes `instanceof Function`
+    // (as used inside reportWebVitals) false for them. Wrap in a plain
+    // function, which passes that check the same way a real callback would.
+    const spy = jest.fn();
+    const onPerfEntry = (...args) => spy(...args);
+    reportWebVitals(onPerfEntry);
+
+    // The vitals functions are loaded via a dynamic import(); flush microtasks.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(mockGetCLS).toHaveBeenCalledWith(onPerfEntry);
+    expect(mockGetFID).toHaveBeenCalledWith(onPerfEntry);
+    expect(mockGetFCP).toHaveBeenCalledWith(onPerfEntry);
+    expect(mockGetLCP).toHaveBeenCalledWith(onPerfEntry);
+    expect(mockGetTTFB).toHaveBeenCalledWith(onPerfEntry);
+  });
+
+  test('does nothing when called without a callback', async () => {
+    reportWebVitals();
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockGetCLS).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when called with a non-function argument', async () => {
+    reportWebVitals('not a function');
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockGetCLS).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/validator/validate.test.mjs
+++ b/frontend/validator/validate.test.mjs
@@ -1,0 +1,90 @@
+// Tests for the blueprint-string validator (schema + Factorio name checks).
+// Run with Node's built-in test runner: node --test validator/validate.test.mjs
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateBlueprintString, decodeBlueprintString } from './validate.mjs';
+import { encodeBlueprint } from '../src/blueprintFactory.js';
+
+function validBlueprint(overrides = {}) {
+  return {
+    blueprint: {
+      icons: [{ signal: { type: 'item', name: 'transport-belt' }, index: 1 }],
+      entities: [
+        { entity_number: 1, name: 'transport-belt', position: { x: 0, y: 0 }, direction: 4 },
+      ],
+      item: 'blueprint',
+      version: 281479275151360,
+      ...overrides,
+    },
+  };
+}
+
+describe('decodeBlueprintString', () => {
+  test('decodes a valid encoded blueprint string back into an object', () => {
+    const bp = validBlueprint();
+    const decoded = decodeBlueprintString(encodeBlueprint(bp));
+    assert.deepEqual(decoded, bp);
+  });
+
+  test('tolerates surrounding whitespace/newlines in the string', () => {
+    const bp = validBlueprint();
+    const encoded = encodeBlueprint(bp);
+    const withWhitespace = `  ${encoded.slice(0, 10)}\n${encoded.slice(10)}  \n`;
+    const decoded = decodeBlueprintString(withWhitespace);
+    assert.deepEqual(decoded, bp);
+  });
+
+  test('throws on corrupted/invalid data', () => {
+    assert.throws(() => decodeBlueprintString('0not-valid-deflate-data'));
+  });
+});
+
+describe('validateBlueprintString', () => {
+  test('accepts a well-formed blueprint with valid entity names', () => {
+    const result = validateBlueprintString(encodeBlueprint(validBlueprint()));
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  test('rejects an entity with a name unknown to Factorio', () => {
+    const bp = validBlueprint();
+    bp.blueprint.entities[0].name = 'not-a-real-entity';
+    const result = validateBlueprintString(encodeBlueprint(bp));
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length > 0);
+    assert.match(result.errors[0], /entityName/);
+  });
+
+  test('rejects a blueprint missing required fields (icons)', () => {
+    const bp = validBlueprint();
+    delete bp.blueprint.icons;
+    const result = validateBlueprintString(encodeBlueprint(bp));
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length > 0);
+  });
+
+  test('rejects a recipe name unknown to Factorio', () => {
+    const bp = validBlueprint();
+    bp.blueprint.entities[0].name = 'assembling-machine-1';
+    bp.blueprint.entities[0].recipe = 'not-a-real-recipe';
+    const result = validateBlueprintString(encodeBlueprint(bp));
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some(e => /recipeName/.test(e)));
+  });
+
+  test('returns a corrupted-string error for garbage input instead of throwing', () => {
+    const result = validateBlueprintString('0not-valid-base64-!!!');
+    assert.equal(result.ok, false);
+    assert.match(result.errors[0], /corrupted blueprint string/);
+  });
+
+  test('reports errors with a non-string data value without crashing', () => {
+    const bp = validBlueprint();
+    // entity_number must be an integer; make it a string to trigger a
+    // schema error where e.data is not itself a string.
+    bp.blueprint.entities[0].entity_number = 'one';
+    const result = validateBlueprintString(encodeBlueprint(bp));
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length > 0);
+  });
+});

--- a/helmod-decoder/.coveragerc
+++ b/helmod-decoder/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+    venv/*
+    tests/*
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.:

--- a/helmod-decoder/helmod_factory.py
+++ b/helmod-decoder/helmod_factory.py
@@ -97,11 +97,8 @@ class HelmodFactory:
         if isinstance(data, dict):
             items = []
             for k, v in data.items():
-                if isinstance(k, str):
-                    if re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', k):
-                        k = k  # Keep valid Lua identifiers unquoted
-                    else:
-                        k = f'["{k}"]'
+                if isinstance(k, str) and not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', k):
+                    k = f'["{k}"]'
                 items.append(f"{k}={HelmodFactory.python_to_lua(v)}")
             return '{' + ','.join(items) + '}'
         elif isinstance(data, list):

--- a/helmod-decoder/requirements-dev.txt
+++ b/helmod-decoder/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=7.4,<10
+pytest-cov>=4.1,<8

--- a/helmod-decoder/tests/conftest.py
+++ b/helmod-decoder/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+# main.py imports its siblings by bare module name
+# (`from helmod_factory import HelmodFactory`), so the package directory
+# needs to be on sys.path regardless of the pytest invocation's cwd.
+PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PACKAGE_DIR not in sys.path:
+    sys.path.insert(0, PACKAGE_DIR)

--- a/helmod-decoder/tests/test_blueprint_factory.py
+++ b/helmod-decoder/tests/test_blueprint_factory.py
@@ -1,0 +1,62 @@
+import pytest
+
+from blueprint_factory import decode_blueprint, encode_blueprint, main
+
+
+class TestEncodeBlueprint:
+    def test_returns_string_starting_with_version_prefix(self):
+        blueprint = {"blueprint": {"item": "blueprint", "entities": []}}
+        encoded = encode_blueprint(blueprint)
+        assert isinstance(encoded, str)
+        assert encoded.startswith("0")
+
+    def test_encode_is_deterministic_for_same_input(self):
+        blueprint = {"blueprint": {"item": "blueprint", "entities": [{"a": 1}]}}
+        assert encode_blueprint(blueprint) == encode_blueprint(blueprint)
+
+
+class TestDecodeBlueprint:
+    def test_round_trip_simple_blueprint(self):
+        blueprint = {
+            "blueprint": {
+                "icons": [{"signal": {"type": "item", "name": "iron-plate"}, "index": 1}],
+                "entities": [
+                    {"entity_number": 1, "name": "assembling-machine-1", "position": {"x": 0, "y": 0}}
+                ],
+                "item": "blueprint",
+                "version": 281479275151360,
+            }
+        }
+        encoded = encode_blueprint(blueprint)
+        decoded = decode_blueprint(encoded)
+        assert decoded == blueprint
+
+    def test_round_trip_empty_entities(self):
+        blueprint = {"blueprint": {"item": "blueprint", "entities": [], "icons": []}}
+        decoded = decode_blueprint(encode_blueprint(blueprint))
+        assert decoded == blueprint
+
+    def test_round_trip_preserves_nested_and_various_types(self):
+        blueprint = {
+            "blueprint": {
+                "item": "blueprint",
+                "entities": [
+                    {
+                        "entity_number": 1,
+                        "name": "inserter",
+                        "position": {"x": -1.5, "y": 2},
+                        "direction": 4,
+                        "flags": None,
+                        "active": True,
+                    }
+                ],
+            }
+        }
+        decoded = decode_blueprint(encode_blueprint(blueprint))
+        assert decoded == blueprint
+
+
+def test_main_does_not_raise():
+    # main() is a documented no-op placeholder; just confirm it's callable
+    # without side effects (for coverage of the __main__ glue).
+    assert main() is None

--- a/helmod-decoder/tests/test_helmod_factory.py
+++ b/helmod-decoder/tests/test_helmod_factory.py
@@ -1,0 +1,144 @@
+import pytest
+
+from helmod_factory import HelmodFactory
+
+
+class TestLuaToPython:
+    def test_flat_table_with_mixed_value_types(self):
+        lua = '{a=1,b="hello",c=true,d=false,e=nil,f=-2.5,["g h"]=3}'
+        result = HelmodFactory.lua_to_python(lua)
+        assert result == {
+            "a": 1,
+            "b": "hello",
+            "c": True,
+            "d": False,
+            "e": None,
+            "f": -2.5,
+            "g h": 3,
+        }
+        # ints stay ints, floats stay floats
+        assert isinstance(result["a"], int)
+        assert isinstance(result["f"], float)
+
+    def test_single_quoted_string_value(self):
+        assert HelmodFactory.lua_to_python("{a='x'}") == {"a": "x"}
+
+    def test_double_quoted_string_value(self):
+        assert HelmodFactory.lua_to_python('{a="x"}') == {"a": "x"}
+
+    def test_bracket_quoted_key(self):
+        assert HelmodFactory.lua_to_python('{["my key"]=1}') == {"my key": 1}
+
+    def test_bracket_quoted_key_single_quotes(self):
+        assert HelmodFactory.lua_to_python("{['my key']=1}") == {"my key": 1}
+
+    def test_unquoted_string_key(self):
+        assert HelmodFactory.lua_to_python("{name=1}") == {"name": 1}
+
+    def test_negative_integer(self):
+        assert HelmodFactory.lua_to_python("{a=-5}") == {"a": -5}
+
+    def test_positive_float(self):
+        assert HelmodFactory.lua_to_python("{a=3.14}") == {"a": 3.14}
+
+    def test_empty_table(self):
+        assert HelmodFactory.lua_to_python("{}") == {}
+
+    def test_multiple_keys(self):
+        result = HelmodFactory.lua_to_python("{a=1,b=2,c=3}")
+        assert result == {"a": 1, "b": 2, "c": 3}
+
+    def test_missing_comma_between_pairs_is_tolerated(self):
+        # Existing (if odd) behavior: a missing comma does not raise, the
+        # parser silently continues on to the next key=value pair.
+        assert HelmodFactory.lua_to_python("{a=1 b=2}") == {"a": 1, "b": 2}
+
+    def test_nested_table_value_raises_value_error(self):
+        # The hand-rolled parser does not correctly support nested tables
+        # as values; this is a known limitation, not something to fix here.
+        with pytest.raises(ValueError):
+            HelmodFactory.lua_to_python("{a={b=1}}")
+
+    def test_array_style_table_raises_value_error(self):
+        # Lua array-style tables (no explicit keys) are not supported.
+        with pytest.raises(ValueError):
+            HelmodFactory.lua_to_python("{1,2,3}")
+
+    def test_missing_equals_after_key_raises_value_error(self):
+        with pytest.raises(ValueError):
+            HelmodFactory.lua_to_python("{a 1}")
+
+    def test_unparseable_value_raises_value_error(self):
+        with pytest.raises(ValueError):
+            HelmodFactory.lua_to_python("{a=$}")
+
+
+class TestPythonToLua:
+    def test_dict_with_simple_identifier_keys(self):
+        assert HelmodFactory.python_to_lua({"a": 1, "b": 2}) == "{a=1,b=2}"
+
+    def test_dict_with_key_needing_brackets(self):
+        assert HelmodFactory.python_to_lua({"my key": 1}) == '{["my key"]=1}'
+
+    def test_string_value_is_quoted(self):
+        assert HelmodFactory.python_to_lua("hi") == '"hi"'
+
+    def test_true_value(self):
+        assert HelmodFactory.python_to_lua(True) == "true"
+
+    def test_false_value(self):
+        assert HelmodFactory.python_to_lua(False) == "false"
+
+    def test_none_value(self):
+        assert HelmodFactory.python_to_lua(None) == "nil"
+
+    def test_int_and_float_values(self):
+        assert HelmodFactory.python_to_lua(5) == "5"
+        assert HelmodFactory.python_to_lua(-2.5) == "-2.5"
+
+    def test_list_value(self):
+        assert HelmodFactory.python_to_lua([1, 2, 3]) == "{1,2,3}"
+
+    def test_nested_dict_serializes_recursively(self):
+        # python_to_lua (unlike lua_to_python) does support nesting.
+        result = HelmodFactory.python_to_lua({"a": {"b": 1}})
+        assert result == "{a={b=1}}"
+
+
+class TestEncodeDecodeHelmodRoundTrip:
+    def test_flat_dict_round_trips(self):
+        data = {"a": 1, "b": "hi", "c": True, "d": False, "e": None, "f": -1.5}
+        encoded = HelmodFactory.encode_helmod(data)
+        assert isinstance(encoded, str)
+        decoded = HelmodFactory.decode_helmod(encoded)
+        assert decoded == data
+
+    def test_encode_produces_base64_string(self):
+        import base64
+
+        encoded = HelmodFactory.encode_helmod({"a": 1})
+        # Should decode as valid base64 without raising.
+        base64.b64decode(encoded)
+
+    def test_decode_strips_embedded_whitespace(self):
+        # Helmod export strings are often copy-pasted with line breaks;
+        # decode_helmod strips all whitespace before base64-decoding.
+        encoded = HelmodFactory.encode_helmod({"a": 1, "b": "hi"})
+        chunk_size = 20
+        chunked = "\n".join(
+            encoded[i : i + chunk_size] for i in range(0, len(encoded), chunk_size)
+        )
+        assert chunked != encoded
+        assert HelmodFactory.decode_helmod(chunked) == {"a": 1, "b": "hi"}
+
+    def test_decode_helmod_from_real_export_file(self):
+        import os
+
+        input_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "input.txt"
+        )
+        with open(input_path) as f:
+            encoded = f.read().strip()
+        decoded = HelmodFactory.decode_helmod(encoded)
+        assert isinstance(decoded, dict)
+        assert decoded.get("owner") == "heliophobicdude"

--- a/helmod-decoder/tests/test_main.py
+++ b/helmod-decoder/tests/test_main.py
@@ -1,0 +1,126 @@
+import io
+import json
+
+import pytest
+
+import main as main_module
+from helmod_factory import HelmodFactory
+
+
+class TestReadInput:
+    def test_reads_from_stdin_when_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(
+            main_module.sys, "stdin", io.StringIO("  hello from stdin  \n")
+        )
+        assert main_module.read_input() == "hello from stdin"
+
+    def test_reads_from_input_file_when_stdin_is_a_tty(self, monkeypatch, tmp_path):
+        class TTYStdin:
+            def isatty(self):
+                return True
+
+        monkeypatch.setattr(main_module.sys, "stdin", TTYStdin())
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "input.txt").write_text("  content from file  \n")
+
+        assert main_module.read_input() == "content from file"
+
+
+class TestParseHelmodData:
+    def test_extracts_item_recipes_from_nested_blocks(self, capsys):
+        helmod_data = {
+            "id": "block_1",
+            "blocks": {
+                "block_1": {
+                    "name": "iron-plate",
+                    "type": "item",
+                    "count": 5,
+                },
+                "block_2": {
+                    "name": "copper-plate",
+                    "type": "item",
+                    "count": 0,
+                },
+            },
+        }
+        recipes = main_module.parse_helmod_data(helmod_data)
+        # "count": 0 is clamped up to a minimum of 1
+        assert recipes == {"iron-plate": 5, "copper-plate": 1}
+
+    def test_defaults_to_iron_plate_when_no_recipes_found(self):
+        recipes = main_module.parse_helmod_data({"foo": "bar"})
+        assert recipes == {"iron-plate": 1}
+
+    def test_ignores_non_item_type_blocks(self):
+        helmod_data = {
+            "name": "some-fluid",
+            "type": "fluid",
+            "count": 3,
+        }
+        recipes = main_module.parse_helmod_data(helmod_data)
+        assert recipes == {"iron-plate": 1}
+
+    def test_uses_default_count_of_one_when_missing(self):
+        helmod_data = {"name": "steel-plate", "type": "item"}
+        recipes = main_module.parse_helmod_data(helmod_data)
+        assert recipes == {"steel-plate": 1}
+
+
+class TestCreateBlueprintFromHelmod:
+    def test_creates_entities_for_each_recipe(self):
+        helmod_data = {"name": "iron-plate", "type": "item", "count": 2}
+        blueprint = main_module.create_blueprint_from_helmod(helmod_data)
+
+        entities = blueprint["blueprint"]["entities"]
+        assert blueprint["blueprint"]["item"] == "blueprint"
+        assemblers = [e for e in entities if e["name"] == "assembling-machine-1"]
+        inserters = [e for e in entities if e["name"] == "inserter"]
+        belts = [e for e in entities if e["name"] == "transport-belt"]
+
+        # count=2 -> two assembling machines, each with 4 inserters + 4 belts
+        assert len(assemblers) == 2
+        assert len(inserters) == 8
+        assert len(belts) == 8
+        assert all(a["recipe"] == "iron-plate" for a in assemblers)
+
+        # entity numbers are unique and sequential
+        numbers = [e["entity_number"] for e in entities]
+        assert numbers == list(range(1, len(entities) + 1))
+
+    def test_creates_blueprint_for_multiple_recipes(self):
+        helmod_data = {
+            "blocks": {
+                "b1": {"name": "iron-plate", "type": "item", "count": 1},
+                "b2": {"name": "copper-plate", "type": "item", "count": 1},
+            }
+        }
+        blueprint = main_module.create_blueprint_from_helmod(helmod_data)
+        recipes_used = {
+            e["recipe"]
+            for e in blueprint["blueprint"]["entities"]
+            if e["name"] == "assembling-machine-1"
+        }
+        assert recipes_used == {"iron-plate", "copper-plate"}
+
+    def test_default_recipe_when_no_data_found(self):
+        blueprint = main_module.create_blueprint_from_helmod({})
+        assemblers = [
+            e
+            for e in blueprint["blueprint"]["entities"]
+            if e["name"] == "assembling-machine-1"
+        ]
+        assert len(assemblers) == 1
+        assert assemblers[0]["recipe"] == "iron-plate"
+
+
+class TestMain:
+    def test_main_reads_decodes_and_prints_blueprint(self, monkeypatch, capsys):
+        helmod_data = {"name": "iron-plate", "type": "item", "count": 1}
+        encoded = HelmodFactory.encode_helmod(helmod_data)
+        monkeypatch.setattr(main_module.sys, "stdin", io.StringIO(encoded))
+
+        main_module.main()
+
+        captured = capsys.readouterr()
+        assert "Encoded blueprint:" in captured.out
+        assert "Final blueprint structure:" in captured.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,6 @@ sonar.organization=afloresescarcega-org
 
 sonar.sources=.
 sonar.exclusions=frontend/node_modules/**,frontend/build/**,helmod-decoder/venv/**,**/__pycache__/**,.idea/**,.aider*/**
+sonar.python.version=3.9
+sonar.python.coverage.reportPaths=helmod-decoder/coverage.xml
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info,frontend/coverage-node/lcov.info


### PR DESCRIPTION
## Summary
- Fixes the Analysis warning about `sonar.python.version` being unset (defaulted for Python 3.9, matching `helmod-decoder/`).
- Fixes the failing SonarQube Cloud Quality Gate, which was failing on `new_reliability_rating`, `new_security_rating`, and `new_coverage`:
  - **Reliability**: removed a useless self-assignment bug in `helmod_factory.py`'s `python_to_lua`.
  - **Security**: tightened `.github/workflows/deploy-pages.yml` — moved `permissions` from workflow-level to job-level (least privilege), and added `--ignore-scripts` to `npm ci` to prevent arbitrary lifecycle-script execution during install.
  - **Coverage**: SonarQube's "new code" leak period is a rolling 30 days, which currently covers essentially the whole repo. Added real test suites and wired coverage into CI:
    - `helmod-decoder/`: 44 pytest tests → 99% coverage (`coverage.xml`)
    - `frontend/src/`: 46 Jest/React Testing Library tests → 98.5% coverage (`lcov.info`)
    - `frontend/cli.mjs` + `frontend/validator/validate.mjs`: 13 tests via Node's built-in test runner → 100% coverage (`lcov.info`)
  - `.github/workflows/sonarqube.yml` now installs deps and runs both test suites (with coverage) before the SonarQube scan step; `sonar-project.properties` points the scanner at all three coverage reports.

Also set the repo's GitHub "website" link to the GitHub Pages URL (`https://afloresescarcega.github.io/factorio-router/`) — done directly via `gh repo edit`, not part of this PR's diff.

## Test plan
- [x] `cd helmod-decoder && python3 -m pytest --cov=. --cov-report=term-missing tests/` — 44 passed, 99% coverage
- [x] `cd frontend && CI=true npx react-scripts test --coverage --watchAll=false` — 46 passed, 98.5% coverage
- [x] `cd frontend && node --test cli.test.mjs validator/validate.test.mjs` — 13 passed, 100% coverage
- [ ] Confirm the SonarQube Cloud Quality Gate turns green after this merges and CI runs

https://claude.ai/code/session_01Wo88oQERzkg8xLpEUdZNbQ