### PR TITLE
Add SonarQube Claude Code integration config

### DIFF
--- a/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-pre-tool-use

--- a/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-prompt-submit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh'",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh'",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 /blueprints/cov_profile.lcov
 .aider*
 /blueprint-output.txt
+
+# Claude Code local/personal settings
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "sonarqube": {
+      "command": "sonar",
+      "args": [
+        "run",
+        "mcp",
+        "--project",
+        "afloresescarcega_factorio-router"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Registers the `sonarqube` MCP server (`.mcp.json`) so Claude Code can query SonarQube Cloud data for this project directly.
- Wires up `PreToolUse`/`UserPromptSubmit` hooks (`.claude/settings.json`, `.claude/hooks/sonar-secrets/**`) that run the Sonar CLI's secret-scanning checks on file reads and prompt submissions.
- `.claude/settings.local.json` (per-machine MCP enablement) is now gitignored rather than committed, since it's personal/local config.

## Test plan
- [ ] Verify `.claude/settings.local.json` stays untracked on a fresh clone
- [ ] Confirm Claude Code picks up the `sonarqube` MCP server and hooks after pulling this branch

https://claude.ai/code/session_01UYK9KrNJSSBd9pGaQUc7Sv