### PR TITLE
Fix remaining SonarQube Quality Gate issues

### DIFF
--- a/frontend/cli.test.mjs
+++ b/frontend/cli.test.mjs
@@ -14,7 +14,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const cliPath = join(here, 'cli.mjs');
 
 function runCli(input, args = []) {
-  return spawnSync('node', [cliPath, ...args], {
+  return spawnSync(process.execPath, [cliPath, ...args], {
     input,
     encoding: 'utf-8',
   });
@@ -54,7 +54,7 @@ describe('cli.mjs', () => {
     // stdout isn't a single clean line -- but the final line is still the
     // blueprint string.
     const lines = result.stdout.trim().split('\n');
-    const lastLine = lines[lines.length - 1];
+    const lastLine = lines.at(-1);
     assert.equal(lastLine[0], '0');
     assert.doesNotThrow(() => decodeBlueprint(lastLine));
   });

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -19,8 +19,8 @@ test('shows an error message when the input cannot be converted', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
   render(<App />);
 
-  await userEvent.type(screen.getByPlaceholderText(/enter helmod string/i), 'not a valid helmod string');
-  await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+  userEvent.type(screen.getByPlaceholderText(/enter helmod string/i), 'not a valid helmod string');
+  userEvent.click(screen.getByRole('button', { name: /convert/i }));
 
   expect(await screen.findByText(/error:/i)).toBeInTheDocument();
   console.error.mockRestore();
@@ -40,8 +40,8 @@ test('shows the resulting blueprint string on a successful conversion', async ()
 
   render(<App />);
   const textarea = screen.getByPlaceholderText(/enter helmod string/i);
-  await userEvent.type(textarea, helmodString);
-  await userEvent.click(screen.getByRole('button', { name: /convert/i }));
+  userEvent.type(textarea, helmodString);
+  userEvent.click(screen.getByRole('button', { name: /convert/i }));
 
   expect(await screen.findByText(/blueprint string:/i)).toBeInTheDocument();
   expect(screen.getByDisplayValue(/^0/)).toBeInTheDocument();

--- a/frontend/src/blueprintFactory.js
+++ b/frontend/src/blueprintFactory.js
@@ -5,7 +5,7 @@ export function decodeBlueprint(encodedBlueprint) {
     const compressedData = atob(encodedBlueprint);
     const uint8Array = new Uint8Array(compressedData.length);
     for (let i = 0; i < compressedData.length; i++) {
-        uint8Array[i] = compressedData.charCodeAt(i);
+        uint8Array[i] = compressedData.codePointAt(i);
     }
     const jsonData = pako.inflate(uint8Array, { to: 'string' });
     const blueprint = JSON.parse(jsonData);
@@ -20,7 +20,7 @@ export function encodeBlueprint(blueprint) {
     let binary = '';
     const CHUNK = 0x8000;
     for (let i = 0; i < compressedData.length; i += CHUNK) {
-        binary += String.fromCharCode.apply(null, compressedData.subarray(i, i + CHUNK));
+        binary += String.fromCodePoint(...compressedData.subarray(i, i + CHUNK));
     }
     return '0' + btoa(binary);
 }

--- a/frontend/src/helmodFactory.js
+++ b/frontend/src/helmodFactory.js
@@ -6,7 +6,7 @@ export class HelmodFactory {
         const decodedData = atob(encodedString);
         const uint8Array = new Uint8Array(decodedData.length);
         for (let i = 0; i < decodedData.length; i++) {
-            uint8Array[i] = decodedData.charCodeAt(i);
+            uint8Array[i] = decodedData.codePointAt(i);
         }
         const decompressedData = pako.inflate(uint8Array, { to: 'string' });
         const luaTable = decompressedData.replace('do local _=', '').replace(';return _;end', '');
@@ -17,7 +17,7 @@ export class HelmodFactory {
         const luaString = HelmodFactory.pythonToLua(data);
         const wrappedLua = `do local _=${luaString};return _;end`;
         const compressedData = pako.deflate(wrappedLua);
-        return btoa(String.fromCharCode.apply(null, compressedData));
+        return btoa(String.fromCodePoint(...compressedData));
     }
 
     static luaToPython(luaString) {
@@ -51,14 +51,46 @@ export class HelmodFactory {
             let match = rest.match(/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/);
             if (match) {
                 i += match[0].length;
-                return /[.eE]/.test(match[0]) ? parseFloat(match[0]) : parseInt(match[0], 10);
+                return /[.eE]/.test(match[0]) ? Number.parseFloat(match[0]) : Number.parseInt(match[0], 10);
             }
-            match = rest.match(/^[a-zA-Z_][a-zA-Z0-9_]*/);
+            match = rest.match(/^[a-zA-Z_]\w*/);
             if (match) {
                 i += match[0].length;
                 return match[0];
             }
             throw new Error(`Unable to parse at ${i}: ${rest.slice(0, 60)}`);
+        }
+
+        function parseBracketKey() {
+            const end = s.indexOf(']', i);
+            if (end === -1) throw new Error(`Unterminated '[' key at ${i}`);
+            let key = s.slice(i + 1, end).trim();
+            if (key.startsWith('"') || key.startsWith("'")) {
+                key = key.slice(1, -1);
+            }
+            i = end + 1;
+            skipWhitespace();
+            if (s[i] !== '=') throw new Error(`Expected '=' after key at ${i}`);
+            i++;
+            return key;
+        }
+
+        function parseTableEntry(result, arrayIndex) {
+            if (s[i] === '[') {
+                const key = parseBracketKey();
+                result[key] = parseValue();
+                return arrayIndex;
+            }
+            const value = parseValue();
+            skipWhitespace();
+            if (s[i] === '=') {
+                i++;
+                result[value] = parseValue();
+                return arrayIndex;
+            }
+            // Bare value: Lua array-style entry
+            result[arrayIndex] = value;
+            return arrayIndex + 1;
         }
 
         function parseTable() {
@@ -67,29 +99,7 @@ export class HelmodFactory {
             let arrayIndex = 1;
             skipWhitespace();
             while (i < s.length && s[i] !== '}') {
-                if (s[i] === '[') {
-                    const end = s.indexOf(']', i);
-                    if (end === -1) throw new Error(`Unterminated '[' key at ${i}`);
-                    let key = s.slice(i + 1, end).trim();
-                    if (key.startsWith('"') || key.startsWith("'")) {
-                        key = key.slice(1, -1);
-                    }
-                    i = end + 1;
-                    skipWhitespace();
-                    if (s[i] !== '=') throw new Error(`Expected '=' after key at ${i}`);
-                    i++;
-                    result[key] = parseValue();
-                } else {
-                    const value = parseValue();
-                    skipWhitespace();
-                    if (s[i] === '=') {
-                        i++;
-                        result[value] = parseValue();
-                    } else {
-                        // Bare value: Lua array-style entry
-                        result[arrayIndex++] = value;
-                    }
-                }
+                arrayIndex = parseTableEntry(result, arrayIndex);
                 skipWhitespace();
                 if (s[i] === ',') {
                     i++;
@@ -104,33 +114,35 @@ export class HelmodFactory {
         return parseValue();
     }
 
-    static pythonToLua(data) {
-        if (typeof data === 'object' && data !== null) {
-            if (Array.isArray(data)) {
-                return '{' + data.map(x => HelmodFactory.pythonToLua(x)).join(',') + '}';
-            } else {
-                const items = [];
-                for (const [k, v] of Object.entries(data)) {
-                    let key = k;
-                    if (typeof k === 'string') {
-                        if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) {
-                            key = k;
-                        } else {
-                            key = `["${k}"]`;
-                        }
-                    }
-                    items.push(`${key}=${HelmodFactory.pythonToLua(v)}`);
-                }
-                return '{' + items.join(',') + '}';
-            }
-        } else if (typeof data === 'string') {
-            return `"${data}"`;
-        } else if (typeof data === 'boolean') {
-            return data ? 'true' : 'false';
-        } else if (data === null) {
-            return 'nil';
-        } else {
-            return String(data);
+    static luaKey(k) {
+        if (typeof k === 'string' && !/^[a-zA-Z_]\w*$/.test(k)) {
+            return `["${k}"]`;
         }
+        return k;
+    }
+
+    static objectToLua(data) {
+        const items = Object.entries(data)
+            .map(([k, v]) => `${HelmodFactory.luaKey(k)}=${HelmodFactory.pythonToLua(v)}`);
+        return '{' + items.join(',') + '}';
+    }
+
+    static pythonToLua(data) {
+        if (Array.isArray(data)) {
+            return '{' + data.map(x => HelmodFactory.pythonToLua(x)).join(',') + '}';
+        }
+        if (data !== null && typeof data === 'object') {
+            return HelmodFactory.objectToLua(data);
+        }
+        if (typeof data === 'string') {
+            return `"${data}"`;
+        }
+        if (typeof data === 'boolean') {
+            return data ? 'true' : 'false';
+        }
+        if (data === null) {
+            return 'nil';
+        }
+        return String(data);
     }
 }

--- a/frontend/src/index.test.js
+++ b/frontend/src/index.test.js
@@ -9,5 +9,5 @@ test('renders into #root without crashing', () => {
     require('./index');
   }).not.toThrow();
 
-  document.body.removeChild(div);
+  div.remove();
 });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,12 +9,12 @@ function parseHelmodData(helmodData) {
 
     function walk(node) {
         if (typeof node !== 'object' || node === null) return;
-        if (node.type === 'recipe' && node.name && node.factory && node.factory.name) {
-            const rawCount = parseFloat(node.factory.count);
+        if (node.type === 'recipe' && node.name && node.factory?.name) {
+            const rawCount = Number.parseFloat(node.factory.count);
             productionUnits.push({
                 recipe: node.name,
                 factory: node.factory.name,
-                count: Math.max(1, Math.ceil(isNaN(rawCount) ? 1 : rawCount)),
+                count: Math.max(1, Math.ceil(Number.isNaN(rawCount) ? 1 : rawCount)),
             });
         }
         for (const value of Object.values(node)) {
@@ -85,6 +85,200 @@ function sortUnits(units) {
     return [...units].sort((a, b) => depth.get(a) - depth.get(b));
 }
 
+// Machines are 3x3 centered on (x, y); items flow west -> east through them.
+// Inserter direction in the blueprint format points at the tile the
+// inserter picks up FROM. Lane offsets from the column center, by
+// ingredient index: 0 -> normal inserter, 1 and 2 -> long-handed.
+const LANE_OFFSETS = [-3, -4, 4];
+const OUTPUT_OFFSET = 3;
+const COLUMN_SPACING = 10;
+const ROW_SPACING = 4;
+const MAX_PER_COLUMN = 15; // wrap tall recipes into multiple columns
+
+function planColumns(productionUnits) {
+    const columns = [];
+    let nextX = 0;
+    for (const unit of productionUnits) {
+        console.log(`Adding ${unit.count}x ${unit.factory} for recipe ${unit.recipe}`);
+        let remaining = unit.count;
+        while (remaining > 0) {
+            const count = Math.min(remaining, MAX_PER_COLUMN);
+            columns.push({x: nextX, unit, count});
+            nextX += COLUMN_SPACING;
+            remaining -= count;
+        }
+    }
+    return columns;
+}
+
+// One bus line per consumed item, in reserved rows above the grid. Rows are
+// 2 apart so branches can hop lower buses with underground belts; 3 rows is
+// the deepest a yellow underground can clear.
+function planBuses(columns) {
+    const busByItem = new Map();
+    for (const column of columns) {
+        column.unit.ingredients.forEach((ingredient, laneIndex) => {
+            if (!busByItem.has(ingredient.name)) {
+                busByItem.set(ingredient.name, {item: ingredient.name, consumers: [], producers: []});
+            }
+            busByItem.get(ingredient.name).consumers.push({column, laneIndex});
+        });
+    }
+    for (const column of columns) {
+        for (const result of column.unit.results) {
+            if (busByItem.has(result.name)) {
+                busByItem.get(result.name).producers.push(column);
+            }
+        }
+    }
+    let buses = [...busByItem.values()];
+    // Intermediates get the rows closest to the machines
+    buses.sort((a, b) => (b.producers.length ? 1 : 0) - (a.producers.length ? 1 : 0));
+    if (buses.length > 3) {
+        const dropped = buses.slice(3);
+        console.warn(`More than 3 items consumed; not routing: ${dropped.map(b => b.item).join(', ')}`);
+        buses = buses.slice(0, 3);
+    }
+    buses.forEach((bus, i) => { bus.row = -4 - 2 * i; });
+    return buses;
+}
+
+function addMachineAndInserters(x, y, unit, add) {
+    const machine = {name: unit.factory, position: {x, y}};
+    if (acceptsRecipe(unit.factory)) {
+        machine.recipe = unit.recipe;
+    }
+    add(machine, [[x - 1, y - 1], [x, y - 1], [x + 1, y - 1],
+                  [x - 1, y], [x, y], [x + 1, y],
+                  [x - 1, y + 1], [x, y + 1], [x + 1, y + 1]]);
+
+    // Output inserter: machine -> east belt
+    add({name: "inserter", position: {x: x + 2, y}, direction: 6});
+    // Input inserters, one per ingredient lane
+    if (unit.ingredients.length > 0) {
+        add({name: "inserter", position: {x: x - 2, y}, direction: 6});
+    }
+    if (unit.ingredients.length > 1) {
+        add({name: "long-handed-inserter", position: {x: x - 2, y: y + 1}, direction: 6});
+    }
+    if (unit.ingredients.length > 2) {
+        add({name: "long-handed-inserter", position: {x: x + 2, y: y + 1}, direction: 2});
+    }
+    // Pole between machines covers inserters on both sides
+    add({name: "medium-electric-pole", position: {x, y: y + 2}});
+}
+
+// Intermediates flow north into their bus, final products flow south and
+// pile up at the bottom.
+function routeOutputLane(x, columnBottom, unit, {belt, underground, busFor}) {
+    const outputX = x + OUTPUT_OFFSET;
+    const feedsBus = unit.results.map(r => busFor(r.name)).find(Boolean);
+    if (feedsBus) {
+        for (let y = -1; y <= columnBottom; y++) {
+            belt(outputX, y, 0);
+        }
+        if (feedsBus.row === -4) {
+            belt(outputX, -2, 0);
+            belt(outputX, -3, 0);
+        } else {
+            underground(outputX, -2, 0, "input");
+            underground(outputX, feedsBus.row + 1, 0, "output");
+        }
+        return;
+    }
+    for (let y = -2; y <= columnBottom; y++) {
+        belt(outputX, y, 4);
+    }
+}
+
+function addMachineColumn({x, unit, count}, {add, belt, underground, busFor}) {
+    const columnBottom = (count - 1) * ROW_SPACING + 1;
+
+    for (let i = 0; i < count; i++) {
+        addMachineAndInserters(x, i * ROW_SPACING, unit, add);
+    }
+    // Relay poles at the top keep neighboring columns connected
+    add({name: "medium-electric-pole", position: {x: x - 2, y: -2}});
+    add({name: "medium-electric-pole", position: {x: x + 2, y: -2}});
+
+    // Ingredient lanes flow south; they are fed by bus taps in addBusLines.
+    unit.ingredients.forEach((ingredient, laneIndex) => {
+        const laneX = x + LANE_OFFSETS[laneIndex];
+        for (let y = -1; y <= columnBottom; y++) {
+            belt(laneX, y, 4);
+        }
+    });
+
+    routeOutputLane(x, columnBottom, unit, {belt, underground, busFor});
+}
+
+function addMachinesAndInserters(columns, ctx) {
+    for (const column of columns) {
+        addMachineColumn(column, ctx);
+    }
+}
+
+// Splitter taps into each consumer lane; branches from the splitter down
+// into the lane.
+function tapBusConsumers(bus, {add, belt, underground}) {
+    const flowsEast = bus.producers.length === 0;
+    const direction = flowsEast ? 2 : 6;
+    const splitterXs = new Set();
+
+    for (const {column, laneIndex} of bus.consumers) {
+        const laneX = column.x + LANE_OFFSETS[laneIndex];
+        const splitterX = flowsEast ? laneX - 1 : laneX + 1;
+        splitterXs.add(splitterX);
+        add({name: "splitter", position: {x: splitterX, y: bus.row + 0.5}, direction},
+            [[splitterX, bus.row], [splitterX, bus.row + 1]]);
+        if (bus.row === -4) {
+            belt(laneX, -3, 4);
+            belt(laneX, -2, 4);
+        } else {
+            underground(laneX, bus.row + 1, 4, "input");
+            underground(laneX, -2, 4, "output");
+        }
+    }
+    return {flowsEast, direction, splitterXs};
+}
+
+function fillBusRow(bus, {flowsEast, direction, splitterXs, feederXs}, belt) {
+    const tapXs = [...splitterXs];
+    const from = flowsEast ? Math.min(...tapXs) - 4 : Math.min(...tapXs);
+    const to = flowsEast ? Math.max(...tapXs) : Math.max(...feederXs);
+    for (let bx = from; bx <= to; bx++) {
+        if (!splitterXs.has(bx)) {
+            belt(bx, bus.row, direction);
+        }
+    }
+    return from;
+}
+
+// Bus lines with splitter taps dropping into each consumer lane. Externals
+// flow east from a west lead-in; intermediates flow west from their
+// producers (sorted east of consumers).
+function addBusLines(buses, {add, belt, underground}) {
+    for (const bus of buses) {
+        const {flowsEast, direction, splitterXs} = tapBusConsumers(bus, {add, belt, underground});
+        const feederXs = bus.producers.map(c => c.x + OUTPUT_OFFSET);
+        const from = fillBusRow(bus, {flowsEast, direction, splitterXs, feederXs}, belt);
+
+        if (flowsEast) {
+            // Label the feed point so a human knows what this lane takes
+            add({
+                name: "constant-combinator",
+                position: {x: from - 1, y: bus.row},
+                control_behavior: {
+                    filters: [{signal: {type: "item", name: bus.item}, count: 1, index: 1}]
+                }
+            });
+        }
+        console.log(`Bus for ${bus.item} on row ${bus.row}, ` +
+            `${flowsEast ? 'east from external input' : 'west from ' + bus.producers.length + ' producer columns'}, ` +
+            `${bus.consumers.length} taps`);
+    }
+}
+
 function createBlueprintFromHelmod(helmodData) {
     const productionUnits = sortUnits(enrichUnits(parseHelmodData(helmodData)));
 
@@ -118,170 +312,12 @@ function createBlueprintFromHelmod(helmodData) {
     const underground = (x, y, direction, type) =>
         add({name: "underground-belt", position: {x, y}, direction, type});
 
-    // Machines are 3x3 centered on (x, y); items flow west -> east through
-    // them. Inserter direction in the blueprint format points at the tile the
-    // inserter picks up FROM. Lane offsets from the column center, by
-    // ingredient index: 0 -> normal inserter, 1 and 2 -> long-handed.
-    const LANE_OFFSETS = [-3, -4, 4];
-    const OUTPUT_OFFSET = 3;
-    const COLUMN_SPACING = 10;
-    const ROW_SPACING = 4;
-    const MAX_PER_COLUMN = 15; // wrap tall recipes into multiple columns
-
-    // 1. Plan columns.
-    const columns = [];
-    let nextX = 0;
-    for (const unit of productionUnits) {
-        console.log(`Adding ${unit.count}x ${unit.factory} for recipe ${unit.recipe}`);
-        let remaining = unit.count;
-        while (remaining > 0) {
-            const count = Math.min(remaining, MAX_PER_COLUMN);
-            columns.push({x: nextX, unit, count});
-            nextX += COLUMN_SPACING;
-            remaining -= count;
-        }
-    }
-
-    // 2. Plan buses: one line per consumed item, in reserved rows above the
-    // grid. Rows are 2 apart so branches can hop lower buses with underground
-    // belts; 3 rows is the deepest a yellow underground can clear.
-    const busByItem = new Map();
-    for (const column of columns) {
-        column.unit.ingredients.forEach((ingredient, laneIndex) => {
-            if (!busByItem.has(ingredient.name)) {
-                busByItem.set(ingredient.name, {item: ingredient.name, consumers: [], producers: []});
-            }
-            busByItem.get(ingredient.name).consumers.push({column, laneIndex});
-        });
-    }
-    for (const column of columns) {
-        for (const result of column.unit.results) {
-            if (busByItem.has(result.name)) {
-                busByItem.get(result.name).producers.push(column);
-            }
-        }
-    }
-    let buses = [...busByItem.values()];
-    // Intermediates get the rows closest to the machines
-    buses.sort((a, b) => (b.producers.length ? 1 : 0) - (a.producers.length ? 1 : 0));
-    if (buses.length > 3) {
-        const dropped = buses.slice(3);
-        console.warn(`More than 3 items consumed; not routing: ${dropped.map(b => b.item).join(', ')}`);
-        buses = buses.slice(0, 3);
-    }
-    buses.forEach((bus, i) => { bus.row = -4 - 2 * i; });
+    const columns = planColumns(productionUnits);
+    const buses = planBuses(columns);
     const busFor = item => buses.find(b => b.item === item);
 
-    // 3. Machines, inserters, poles and vertical lanes per column.
-    for (const {x, unit, count} of columns) {
-        const columnBottom = (count - 1) * ROW_SPACING + 1;
-
-        for (let i = 0; i < count; i++) {
-            const y = i * ROW_SPACING;
-            const machine = {name: unit.factory, position: {x, y}};
-            if (acceptsRecipe(unit.factory)) {
-                machine.recipe = unit.recipe;
-            }
-            add(machine, [[x - 1, y - 1], [x, y - 1], [x + 1, y - 1],
-                          [x - 1, y], [x, y], [x + 1, y],
-                          [x - 1, y + 1], [x, y + 1], [x + 1, y + 1]]);
-
-            // Output inserter: machine -> east belt
-            add({name: "inserter", position: {x: x + 2, y}, direction: 6});
-            // Input inserters, one per ingredient lane
-            if (unit.ingredients.length > 0) {
-                add({name: "inserter", position: {x: x - 2, y}, direction: 6});
-            }
-            if (unit.ingredients.length > 1) {
-                add({name: "long-handed-inserter", position: {x: x - 2, y: y + 1}, direction: 6});
-            }
-            if (unit.ingredients.length > 2) {
-                add({name: "long-handed-inserter", position: {x: x + 2, y: y + 1}, direction: 2});
-            }
-            // Pole between machines covers inserters on both sides
-            add({name: "medium-electric-pole", position: {x, y: y + 2}});
-        }
-        // Relay poles at the top keep neighboring columns connected
-        add({name: "medium-electric-pole", position: {x: x - 2, y: -2}});
-        add({name: "medium-electric-pole", position: {x: x + 2, y: -2}});
-
-        // Ingredient lanes flow south; they are fed by bus taps in step 4.
-        unit.ingredients.forEach((ingredient, laneIndex) => {
-            const laneX = x + LANE_OFFSETS[laneIndex];
-            for (let y = -1; y <= columnBottom; y++) {
-                belt(laneX, y, 4);
-            }
-        });
-
-        // Output lane: intermediates flow north into their bus, final
-        // products flow south and pile up at the bottom.
-        const outputX = x + OUTPUT_OFFSET;
-        const feedsBus = unit.results.map(r => busFor(r.name)).find(Boolean);
-        if (feedsBus) {
-            for (let y = -1; y <= columnBottom; y++) {
-                belt(outputX, y, 0);
-            }
-            if (feedsBus.row === -4) {
-                belt(outputX, -2, 0);
-                belt(outputX, -3, 0);
-            } else {
-                underground(outputX, -2, 0, "input");
-                underground(outputX, feedsBus.row + 1, 0, "output");
-            }
-        } else {
-            for (let y = -2; y <= columnBottom; y++) {
-                belt(outputX, y, 4);
-            }
-        }
-    }
-
-    // 4. Bus lines with splitter taps dropping into each consumer lane.
-    for (const bus of buses) {
-        // Externals flow east from a west lead-in; intermediates flow west
-        // from their producers (sorted east of consumers).
-        const flowsEast = bus.producers.length === 0;
-        const direction = flowsEast ? 2 : 6;
-        const splitterXs = new Set();
-
-        for (const {column, laneIndex} of bus.consumers) {
-            const laneX = column.x + LANE_OFFSETS[laneIndex];
-            const splitterX = flowsEast ? laneX - 1 : laneX + 1;
-            splitterXs.add(splitterX);
-            add({name: "splitter", position: {x: splitterX, y: bus.row + 0.5}, direction},
-                [[splitterX, bus.row], [splitterX, bus.row + 1]]);
-            // Branch from the splitter down into the lane
-            if (bus.row === -4) {
-                belt(laneX, -3, 4);
-                belt(laneX, -2, 4);
-            } else {
-                underground(laneX, bus.row + 1, 4, "input");
-                underground(laneX, -2, 4, "output");
-            }
-        }
-
-        const tapXs = [...splitterXs];
-        const feederXs = bus.producers.map(c => c.x + OUTPUT_OFFSET);
-        const from = flowsEast ? Math.min(...tapXs) - 4 : Math.min(...tapXs);
-        const to = flowsEast ? Math.max(...tapXs) : Math.max(...feederXs);
-        for (let bx = from; bx <= to; bx++) {
-            if (!splitterXs.has(bx)) {
-                belt(bx, bus.row, direction);
-            }
-        }
-        if (flowsEast) {
-            // Label the feed point so a human knows what this lane takes
-            add({
-                name: "constant-combinator",
-                position: {x: from - 1, y: bus.row},
-                control_behavior: {
-                    filters: [{signal: {type: "item", name: bus.item}, count: 1, index: 1}]
-                }
-            });
-        }
-        console.log(`Bus for ${bus.item} on row ${bus.row}, ` +
-            `${flowsEast ? 'east from external input' : 'west from ' + bus.producers.length + ' producer columns'}, ` +
-            `${bus.consumers.length} taps`);
-    }
+    addMachinesAndInserters(columns, {add, belt, underground, busFor});
+    addBusLines(buses, {add, belt, underground});
 
     console.log(`Total entities added: ${entities.length}`);
     return blueprint;

--- a/frontend/src/reportWebVitals.js
+++ b/frontend/src/reportWebVitals.js
@@ -1,5 +1,5 @@
 const reportWebVitals = onPerfEntry => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
+  if (onPerfEntry && typeof onPerfEntry === 'function') {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);

--- a/helmod-decoder/helmod_factory.py
+++ b/helmod-decoder/helmod_factory.py
@@ -4,6 +4,78 @@ import json
 import re
 
 
+def _parse_lua_literal(s):
+    match = re.match(r'-?\d+(?:\.\d+)?', s)
+    if match:
+        return float(match.group()) if '.' in match.group() else int(match.group()), match.end()
+    # Handle unquoted string keys
+    match = re.match(r'[a-zA-Z_]\w*', s)
+    if match:
+        return match.group(), match.end()
+    raise ValueError(f"Unable to parse: {s}")
+
+
+def _parse_lua_value(s, i):
+    s = s[i:].lstrip()
+    if s.startswith('{'):
+        return _parse_lua_table(s)
+    if s.startswith('"'):
+        end = s.index('"', 1)
+        return s[1:end], end + 1
+    if s.startswith("'"):
+        end = s.index("'", 1)
+        return s[1:end], end + 1
+    if s.startswith('true'):
+        return True, 4
+    if s.startswith('false'):
+        return False, 5
+    if s.startswith('nil'):
+        return None, 3
+    return _parse_lua_literal(s)
+
+
+def _parse_bracket_key(s):
+    end = s.index(']')
+    key = s[1:end].strip()
+    if key.startswith(('"', "'")):
+        key = key[1:-1]
+    return key, s[end + 1:].lstrip()
+
+
+def _parse_table_key(s):
+    if s.startswith('['):
+        return _parse_bracket_key(s)
+    key, end = _parse_lua_value(s, 0)
+    return key, s[end:].lstrip()
+
+
+def _parse_lua_table(s):
+    result = {}
+    s = s[1:].lstrip()  # Remove opening '{'
+    while s and not s.startswith('}'):
+        key, s = _parse_table_key(s)
+
+        if not s.startswith('='):
+            raise ValueError(f"Expected '=' after key, found: {s}")
+        s = s[1:].lstrip()
+
+        value, end = _parse_lua_value(s, 0)
+        s = s[end:].lstrip()
+
+        result[key] = value
+
+        if s.startswith(','):
+            s = s[1:].lstrip()
+        elif not s.startswith('}') and not s:
+            # If there's more content but no comma, tolerate it and keep parsing.
+            raise ValueError(f"Expected ',' or '}}', found: {s}")
+
+    if not s.startswith('}'):
+        raise ValueError(f"Expected '}}', found: {s}")
+
+    return result, len(s) - len(s.lstrip('}'))
+
+
 class HelmodFactory:
     @staticmethod
     def decode_helmod(encoded_string):
@@ -25,79 +97,14 @@ class HelmodFactory:
 
     @staticmethod
     def lua_to_python(lua_string):
-        def parse_value(s, i):
-            s = s[i:].lstrip()
-            if s.startswith('{'):
-                return parse_table(s)
-            elif s.startswith('"'):
-                end = s.index('"', 1)
-                return s[1:end], end + 1
-            elif s.startswith("'"):
-                end = s.index("'", 1)
-                return s[1:end], end + 1
-            elif s.startswith('true'):
-                return True, 4
-            elif s.startswith('false'):
-                return False, 5
-            elif s.startswith('nil'):
-                return None, 3
-            else:
-                match = re.match(r'-?\d+(?:\.\d+)?', s)
-                if match:
-                    return float(match.group()) if '.' in match.group() else int(match.group()), match.end()
-                else:
-                    # Handle unquoted string keys
-                    match = re.match(r'[a-zA-Z_][a-zA-Z0-9_]*', s)
-                    if match:
-                        return match.group(), match.end()
-                    raise ValueError(f"Unable to parse: {s}")
-
-        def parse_table(s):
-            result = {}
-            s = s[1:].lstrip()  # Remove opening '{'
-            while s and not s.startswith('}'):
-                # Parse key
-                if s.startswith('['):
-                    end = s.index(']')
-                    key = s[1:end].strip()
-                    if key.startswith('"') or key.startswith("'"):
-                        key = key[1:-1]
-                    s = s[end + 1:].lstrip()
-                else:
-                    key, end = parse_value(s, 0)
-                    s = s[end:].lstrip()
-
-                if not s.startswith('='):
-                    raise ValueError(f"Expected '=' after key, found: {s}")
-                s = s[1:].lstrip()
-
-                # Parse value
-                value, end = parse_value(s, 0)
-                s = s[end:].lstrip()
-
-                result[key] = value
-
-                if s.startswith(','):
-                    s = s[1:].lstrip()
-                elif not s.startswith('}'):
-                    # If we're not at the end of this table, continue parsing
-                    if s:
-                        continue
-                    raise ValueError(f"Expected ',' or '}}', found: {s}")
-
-            if not s.startswith('}'):
-                raise ValueError(f"Expected '}}', found: {s}")
-
-            return result, len(s) - len(s.lstrip('}'))
-
-        return parse_value(lua_string, 0)[0]
+        return _parse_lua_value(lua_string, 0)[0]
 
     @staticmethod
     def python_to_lua(data):
         if isinstance(data, dict):
             items = []
             for k, v in data.items():
-                if isinstance(k, str) and not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', k):
+                if isinstance(k, str) and not re.match(r'^[a-zA-Z_]\w*$', k):
                     k = f'["{k}"]'
                 items.append(f"{k}={HelmodFactory.python_to_lua(v)}")
             return '{' + ','.join(items) + '}'


### PR DESCRIPTION
## Summary
Fixes the 26 open issues reported by `sonar list issues --project afloresescarcega_factorio-router`:

- **Mechanical cleanups**: `Number.parseInt`/`Number.parseFloat`/`Number.isNaN` over the globals, `String#codePointAt()`/`String.fromCodePoint()` over the `charCodeAt`/`fromCharCode` equivalents, `\w` instead of `[a-zA-Z0-9_]` character classes, `key.startswith(('"', "'"))` tuple form over chained calls, optional chaining, `Array#at(-1)`, `childNode.remove()`, `typeof x === 'function'` over `instanceof Function`, and using `process.execPath` instead of a bare `'node'` PATH lookup in the test helper.
- **Cognitive Complexity refactors** (the 4 CRITICAL findings): split up the worst offenders into small, single-purpose functions with no behavior change:
  - `main.js` `createBlueprintFromHelmod` (64 → orchestrator calling `planColumns`/`planBuses`/`addMachinesAndInserters`/`addBusLines` and their helpers)
  - `helmodFactory.js` `parseTable` (21) and `pythonToLua` (24)
  - `helmod_factory.py` `lua_to_python` (45 — inflated because the Python Sonar analyzer folds nested closures into the enclosing function's score; pulled the recursive-descent parser out to module-level functions)

All refactors preserve the exact same `add()`/`belt()`/`underground()` call order and Lua-parsing behavior, so generated blueprints and encode/decode output are unchanged.

## Test plan
- [x] `python -m pytest -q` in `helmod-decoder/` — 44 passed
- [x] `CI=true npx react-scripts test --watchAll=false` in `frontend/` — 46 passed, 6 suites
- [ ] SonarQube Cloud CI re-analysis on this PR shows the Quality Gate passing

https://claude.ai/code/session_01UYK9KrNJSSBd9pGaQUc7Sv