### PR TITLE
Fix SonarQube New Code coverage gate

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,9 +2,9 @@ sonar.projectKey=afloresescarcega_factorio-router
 sonar.organization=afloresescarcega-org
 
 sonar.sources=.
-sonar.exclusions=frontend/node_modules/**,frontend/build/**,helmod-decoder/venv/**,**/__pycache__/**,.idea/**,.aider*/**
-sonar.tests=helmod-decoder/tests
-sonar.test.inclusions=helmod-decoder/tests/**
+sonar.exclusions=frontend/node_modules/**,frontend/build/**,helmod-decoder/venv/**,**/__pycache__/**,.idea/**,.aider*/**,frontend/src/**/*.test.js,frontend/cli.test.mjs,frontend/validator/**/*.test.mjs,helmod-decoder/tests/**
+sonar.tests=helmod-decoder/tests,frontend
+sonar.test.inclusions=helmod-decoder/tests/**,frontend/src/**/*.test.js,frontend/cli.test.mjs,frontend/validator/**/*.test.mjs
 sonar.python.version=3.9
 sonar.python.coverage.reportPaths=helmod-decoder/coverage.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info,frontend/coverage-node/lcov.info


### PR DESCRIPTION
## Summary
- The Quality Gate was failing on New Code coverage (65.5% vs 80% required) because the project's "new code" period defaults to the first analysis date, so nearly the entire codebase counted as new.
- Frontend test files (`*.test.js`, `cli.test.mjs`, `validator/validate.test.mjs`) were indexed as regular source under `sonar.sources=.`, but Jest/Node's coverage tools don't instrument test files themselves — so every line in them showed as 0% covered new code, dragging the New Code coverage average way down.
- Declared those files as tests via `sonar.tests` / `sonar.test.inclusions` (mirroring the existing `helmod-decoder/tests` setup for Python), and excluded them from `sonar.sources` so they aren't double-indexed.
- Confirmed via the SonarQube API that after excluding test files, the remaining new-code lines-to-cover/uncovered ratio is ~96%, well above the 80% gate.

## Test plan
- [x] `npm test -- --coverage --watchAll=false` passes (46 tests)
- [x] `node --experimental-test-coverage --test cli.test.mjs validator/validate.test.mjs` passes (13 tests)
- [x] `pytest --cov=. tests/` passes (44 tests)
- [ ] Confirm SonarQube Cloud Scan on this PR reports the Quality Gate as passing

https://claude.ai/code/session_01UYK9KrNJSSBd9pGaQUc7Sv